### PR TITLE
Use symlinks instead of alias

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 {
   CURRENT_DIR=$( cd "$( dirname "$0" )" && pwd )
   INSTALL_DIR="$HOME/.juliavm"
+  PATH_DIR="$HOME/.local/bin"
 
   juliavm_echo() {
     command printf %s\\n "$*" 2>/dev/null || {
@@ -23,14 +24,12 @@
   }
 
   juliavm_create_directories(){
-    eval 'mkdir $INSTALL_DIR'
-    eval 'mkdir $INSTALL_DIR/dists'
+    eval 'mkdir -p $INSTALL_DIR/dists'
+    eval 'mkdir -p $PATH_DIR'
   }
 
   juliavm_copy_files(){
-    eval 'cp $CURRENT_DIR/juliavm.sh $INSTALL_DIR/juliavm'
-    echo "alias juliavm='$INSTALL_DIR/juliavm'" >> ~/.bashrc && exec bash
-    eval 'cp -r $CURRENT_DIR/.git $INSTALL_DIR'
+    eval 'cp $CURRENT_DIR/juliavm.sh $PATH_DIR/juliavm'
   }
 
   juliavm_install

--- a/juliavm.sh
+++ b/juliavm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/bash
 
 { # this ensures the entire script is downloaded #
 
@@ -45,6 +45,11 @@ juliavm_install(){
   fi
   juliavm_echo "Julia "$1" installed!"
   juliavm_use $1
+  
+  if [[ :$PATH: != *":$HOME/.local/bin:"* ]] ; then
+    juliavm_echo "$HOME/.local/bin was not found in your PATH!"
+    juliavm_echo "You won't be able to run julia (once you close this terminal)"
+  fi
 }
 
 juliavm_use(){
@@ -55,9 +60,8 @@ juliavm_use(){
   else
     EXEC_PATH="$JULIAVM_WORK_DIR/dists/$1/bin/julia"
   fi
-  sed -i /'alias julia='/d  ~/.bashrc
+  ln -nsf $EXEC_PATH $HOME/.local/bin/julia
   juliavm_echo "You're using Julia $1$2"
-  juliavm_echo "alias julia='$EXEC_PATH'" >> ~/.bashrc && exec bash
 }
 
 juliavm_ls(){
@@ -174,9 +178,9 @@ juliavm_uninstall(){
   fi
 
   DIR=$( cd "$( dirname "$0" )" && pwd )
-  sed -i /'alias julia='/d  ~/.bashrc
-  sed -i /'alias juliavm='/d  ~/.bashrc
-  command rm -r ~/.juliavm
+
+  command test -f ${HOME}/.local/bin/julia && command rm ${HOME}/.local/bin/julia
+  command test -f ${HOME}/.local/bin/juliavm && command rm ${HOME}/.local/bin/juliavm
   command unset JULIAVM_JULIA_REPO
   command unset JULIAVM_JULIA_AWS
   command unset JULIAVM_WORK_DIR

--- a/juliavm.sh
+++ b/juliavm.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
 { # this ensures the entire script is downloaded #
+PATH_DIR="$HOME/.local/bin"
 
 # Setup mirror location if not already set
 export JULIAVM_JULIA_REPO="https://github.com/JuliaLang/julia"
 export JULIAVM_JULIA_AWS="https://julialang-s3.julialang.org/bin/linux/"
-export JULIAVM_WORK_DIR
-JULIAVM_WORK_DIR=$( cd "$( dirname "$0" )" && pwd )
+export JULIAVM_WORK_DIR=$HOME/.juliavm
 
 juliavm_echo() {
   command printf %s\\n "$*" 2>/dev/null || {
@@ -28,26 +28,25 @@ juliavm_install(){
   url=$(juliavm_get_download_url "$1" "$2")
 
   dists_dir=$(juliavm_get_dist_dir "$1" "$2")
+  dists_file=$dists_dir/$file.tar.gz
 
-  if [ -d "$dists_dir" ]; then
-    juliavm_echo $dists_dir' already exist'
-  else
-    juliavm_echo 'Creating directories ...'
-    command mkdir "$dists_dir"
-    command cd "$dists_dir"
-    juliavm_echo 'Downlowding files ...'
-    command curl -O "$url"
-    command cd "$JULIAVM_WORK_DIR"
-    juliavm_echo 'Unzip files ...'
-    command tar -xvzf "$dists_dir"/"$file".tar.gz -C "$dists_dir" --strip-components=1
-    juliavm_echo 'Cleaning ...'
-    command rm "$dists_dir"/"$file".tar.gz
-  fi
+  command mkdir -p "$dists_dir"
+
+  curdir=$(pwd)
+
+  command cd "$dists_dir"
+  juliavm_echo 'Downlowding files ...'
+  command curl -O "$url"
+  command cd "$JULIAVM_WORK_DIR"
+  juliavm_echo 'Unzip files ...'
+  command tar -xvzf $dists_file -C "$dists_dir" --strip-components=1
+  juliavm_echo 'Cleaning ...'
+  command test -f $dists_file && command rm $dists_file
   juliavm_echo "Julia "$1" installed!"
   juliavm_use $1
   
-  if [[ :$PATH: != *":$HOME/.local/bin:"* ]] ; then
-    juliavm_echo "$HOME/.local/bin was not found in your PATH!"
+  if [[ :$PATH: != *":$PATH_DIR:"* ]] ; then
+    juliavm_echo "$PATH_DIR was not found in your PATH!"
     juliavm_echo "You won't be able to run julia (once you close this terminal)"
   fi
 }
@@ -60,7 +59,7 @@ juliavm_use(){
   else
     EXEC_PATH="$JULIAVM_WORK_DIR/dists/$1/bin/julia"
   fi
-  ln -nsf $EXEC_PATH $HOME/.local/bin/julia
+  ln -nsf $EXEC_PATH $PATH_DIR/julia
   juliavm_echo "You're using Julia $1$2"
 }
 
@@ -179,8 +178,9 @@ juliavm_uninstall(){
 
   DIR=$( cd "$( dirname "$0" )" && pwd )
 
-  command test -h ${HOME}/.local/bin/julia && command rm ${HOME}/.local/bin/julia
-  command test -h ${HOME}/.local/bin/juliavm && command rm ${HOME}/.local/bin/juliavm
+  command test -h $PATH_DIR/julia && command rm $PATH_DIR/julia
+  command test -f $PATH_DIR/juliavm && command rm $PATH_DIR/juliavm
+  command test -d $HOME/.juliavm && command rm -r $HOME/.juliavm
   command unset JULIAVM_JULIA_REPO
   command unset JULIAVM_JULIA_AWS
   command unset JULIAVM_WORK_DIR

--- a/juliavm.sh
+++ b/juliavm.sh
@@ -179,8 +179,8 @@ juliavm_uninstall(){
 
   DIR=$( cd "$( dirname "$0" )" && pwd )
 
-  command test -f ${HOME}/.local/bin/julia && command rm ${HOME}/.local/bin/julia
-  command test -f ${HOME}/.local/bin/juliavm && command rm ${HOME}/.local/bin/juliavm
+  command test -h ${HOME}/.local/bin/julia && command rm ${HOME}/.local/bin/julia
+  command test -h ${HOME}/.local/bin/juliavm && command rm ${HOME}/.local/bin/juliavm
   command unset JULIAVM_JULIA_REPO
   command unset JULIAVM_JULIA_AWS
   command unset JULIAVM_WORK_DIR


### PR DESCRIPTION
By using symlinks in `~/.local/bin` the new version of `julia` is available without having to source the `bashrc` file.  Also this means that the `.bashrc` file does not need to keep changing between `julia` version switches.

My `bashrc` is a symlink from `~/dotfiles`.  With the current version, my symlink is broken and I have to relink.  If I forget to relink then my changes in the `.bashrc` don't get tracked by `git` and I have to manually rebase.